### PR TITLE
fix(plugin): do not panic at the EOF error

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/vincenzopalazzo/cln4go/comm/encoder"
@@ -197,6 +198,9 @@ func (self *Plugin[T]) Start() {
 			bytesResp1, err := reader.Read(recvData[:])
 
 			if err != nil {
+				if err == io.EOF {
+					break
+				}
 				panic(err)
 			}
 			rawRequest = append(rawRequest, recvData[:bytesResp1]...)


### PR DESCRIPTION
Currently we panic when the io reader when
it is returned an error. We should accept a io.EOF error, so this patch is fixing the following crash

running 2 tests
panic: EOF

goroutine 1 [running]:
github.com/vincenzopalazzo/cln4go/plugin.(*Plugin[...]).Start(0x575a60)
	/home/vincent/github/work/ocean/cln-offers/vendor/github.com/vincenzopalazzo/cln4go/plugin/plugin.go:200 +0x696
main.main()
	/home/vincent/github/work/ocean/cln-offers/cmd/plugin.go:17 +0x291