### PR TITLE
client: harden UnixRPC error handling and documentation

### DIFF
--- a/client/unix_test.go
+++ b/client/unix_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"testing"
 )
@@ -10,58 +9,56 @@ import (
 func TestUnixCallOne(t *testing.T) {
 	path := os.Getenv("CLN_UNIX_SOCKET")
 	if path == "" {
-		err := fmt.Errorf("Unix path not exported with the CLN_UNIX_SOCKET env variable")
-		panic(err)
+		t.Skip("CLN_UNIX_SOCKET not set, skipping integration test")
 	}
 
 	client, err := NewUnix(path)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	response, err := Call[map[string]any, map[string]any](client, "getinfo", map[string]any{})
 
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	if response == nil {
-		panic("The get info is null, there is some problem with the client implementation")
+		t.Fatal("getinfo returned nil response")
 	}
 
 	if response["id"] == "" {
 		resp, _ := json.Marshal(response)
-		panic(fmt.Sprintf("Response received by the node is invalid: %s", string(resp)))
+		t.Fatalf("response missing id field: %s", string(resp))
 	}
 }
 
 type MapReq = map[string]any
 type GetInfo struct {
-	network string
+	Network string `json:"network"`
 }
 
 func TestUnixCallOneTyped(t *testing.T) {
 	path := os.Getenv("CLN_UNIX_SOCKET")
 	if path == "" {
-		err := fmt.Errorf("Unix path not exported with the CLN_UNIX_SOCKET env variable")
-		panic(err)
+		t.Skip("CLN_UNIX_SOCKET not set, skipping integration test")
 	}
 
 	client, err := NewUnix(path)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	response, err := Call[MapReq, *GetInfo](client, "getinfo", make(map[string]any, 0))
 
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	if response == nil {
-		panic("The get info is null, there is some problem with the client implementation")
+		t.Fatal("getinfo returned nil response")
 	}
 
-	if response.network == "bitcoin" {
-		panic("the network should be different from the bitcoin one")
+	if response.Network == "" {
+		t.Fatal("expected non-empty network field in getinfo response")
 	}
 }

--- a/client/unix_unit_test.go
+++ b/client/unix_unit_test.go
@@ -1,0 +1,161 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vincenzopalazzo/cln4go/comm/jsonrpcv2"
+)
+
+// startTestServer creates a temporary Unix socket and starts a goroutine
+// that accepts connections and handles them with the provided function.
+// Uses /tmp with a short name to stay within the Unix socket path length limit.
+func startTestServer(t *testing.T, handler func(net.Conn)) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "cln4go-*.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := f.Name()
+	f.Close()
+	os.Remove(path)
+	t.Cleanup(func() { os.Remove(path) })
+
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(fmt.Errorf("listen %s: %w", path, err))
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go handler(conn)
+		}
+	}()
+	return path
+}
+
+func TestNewUnixEmptyPath(t *testing.T) {
+	_, err := NewUnix("")
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestCallDialFailure(t *testing.T) {
+	client, err := NewUnix("/nonexistent/path/test.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Call[map[string]any, map[string]any](client, "getinfo", map[string]any{})
+	if err == nil {
+		t.Fatal("expected dial error")
+	}
+	if !strings.Contains(err.Error(), "connecting to unix socket") {
+		t.Fatalf("expected dial context in error, got: %v", err)
+	}
+}
+
+func TestCallServerCloseWithoutResponse(t *testing.T) {
+	path := startTestServer(t, func(conn net.Conn) {
+		// Read the request to avoid broken pipe on the client side,
+		// then close without writing a response.
+		buf := make([]byte, 4096)
+		conn.Read(buf)
+		conn.Close()
+	})
+
+	client, err := NewUnix(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Call[map[string]any, map[string]any](client, "getinfo", map[string]any{})
+	if !errors.Is(err, ErrServerClosed) {
+		t.Fatalf("expected ErrServerClosed, got: %v", err)
+	}
+}
+
+func TestCallServerRPCError(t *testing.T) {
+	path := startTestServer(t, func(conn net.Conn) {
+		buf := make([]byte, 4096)
+		conn.Read(buf)
+		resp := `{"jsonrpc":"2.0","id":"cln4go/1","error":{"code":-32601,"message":"Unknown command"}}` + "\n\n"
+		conn.Write([]byte(resp))
+		conn.Close()
+	})
+
+	client, err := NewUnix(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Call[map[string]any, map[string]any](client, "nonexistent", map[string]any{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var jrpcErr *jsonrpcv2.JSONRPCError
+	if !errors.As(err, &jrpcErr) {
+		t.Fatalf("expected *JSONRPCError, got %T: %v", err, err)
+	}
+	if jrpcErr.Code != -32601 {
+		t.Fatalf("expected error code -32601, got %d", jrpcErr.Code)
+	}
+}
+
+func TestCallSuccess(t *testing.T) {
+	path := startTestServer(t, func(conn net.Conn) {
+		buf := make([]byte, 4096)
+		conn.Read(buf)
+		resp := `{"jsonrpc":"2.0","id":"cln4go/1","result":{"id":"test-node-id","alias":"test"}}` + "\n\n"
+		conn.Write([]byte(resp))
+		conn.Close()
+	})
+
+	client, err := NewUnix(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := Call[map[string]any, map[string]any](client, "getinfo", map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result["id"] != "test-node-id" {
+		t.Fatalf("expected id=test-node-id, got %v", result["id"])
+	}
+}
+
+func TestCallSuccessTyped(t *testing.T) {
+	type InfoResult struct {
+		Id    string `json:"id"`
+		Alias string `json:"alias"`
+	}
+
+	path := startTestServer(t, func(conn net.Conn) {
+		buf := make([]byte, 4096)
+		conn.Read(buf)
+		resp := `{"jsonrpc":"2.0","id":"cln4go/1","result":{"id":"test-node-id","alias":"test-alias"}}` + "\n\n"
+		conn.Write([]byte(resp))
+		conn.Close()
+	})
+
+	client, err := NewUnix(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := Call[map[string]any, *InfoResult](client, "getinfo", map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Id != "test-node-id" {
+		t.Fatalf("expected id=test-node-id, got %s", result.Id)
+	}
+	if result.Alias != "test-alias" {
+		t.Fatalf("expected alias=test-alias, got %s", result.Alias)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up fixes from reviewing the `fix/socket-reuse-timeout` branch. Each commit is atomic and addresses a single concern:

- **Validate socket path in `NewUnix`** — reject empty paths at construction time so the error return is meaningful and callers get a fast-fail rather than a confusing error on the first `Call`
- **Return error from `encodeToBytes` instead of panicking** — replace the `panic` with a proper error return so callers get a recoverable error when JSON marshaling fails
- **Document concurrency safety expectations** — clarify that `Call` is safe for concurrent use but setter methods (`SetTracer`, `SetEncoder`, `SetTimeout`) must only be called during initialization
- **Document timeout behavior for CLN blocking RPCs** — note that `waitanyinvoice`, `waitblockheight`, and similar blocking RPCs may need a custom or disabled timeout
- **Fix comment style and typo** — add space after `//` per Go conventions and fix "anther" → "another"

## Test plan

- [ ] Verify `go build ./client/...` passes (already confirmed locally)
- [ ] Verify existing integration tests still pass with a running CLN node
- [ ] Confirm `NewUnix("")` now returns an error instead of `nil`

🤖 Generated with [Claude Code](https://claude.com/claude-code)